### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/envi_heater/__init__.py
+++ b/custom_components/envi_heater/__init__.py
@@ -48,7 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     # Forward to climate platform
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "climate")
+        hass.config_entries.async_forward_entry_setups(entry, ["climate"])
     )
 
     return True


### PR DESCRIPTION
haas.config_entries.async_forward_entry_setup deprecated recently:

https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/

"Calling hass.config_entries.async_forward_entry_setup is deprecated and will be removed in Home Assistant 2025.6. Instead, await hass.config_entries.async_forward_entry_setups as it can load multiple platforms at once and is more efficient since it does not require a separate import executor job for each platform."

Updated to the new call, adjusting the arguments to work with the new function, which expects a list of platform configurations.