### PR TITLE
Fix token check condition in _request method

### DIFF
--- a/custom_components/envi_heater/api.py
+++ b/custom_components/envi_heater/api.py
@@ -101,7 +101,7 @@ class EnviApiClient:
 
     async def _request(self, method: str, endpoint: str, **kwargs) -> dict:
         """Internal request with automatic token refresh."""
-        if not self.token is None:
+        if self.token is None:
             await self.authenticate()
 
         # Refresh token if within 5 minutes of expiry


### PR DESCRIPTION
The original test was "if token exists then authenticate".  Removed the "not" so we auth if the token does not exist, which would be the desired behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized authentication token handling to prevent unnecessary token renewal, improving API request efficiency and response times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->